### PR TITLE
Add apple_preprocessed_plist rule

### DIFF
--- a/apple/apple_preprocessed_plist.bzl
+++ b/apple/apple_preprocessed_plist.bzl
@@ -1,0 +1,61 @@
+load("//apple:string_dict_select_values.bzl", "string_dict_select_values")
+
+def _impl(ctx):
+    substitutions = {}
+    for key, value in ctx.attr.items():
+        substitutions["${" + key + "}"] = value
+        substitutions["$(" + key + ")"] = value
+
+    output = ctx.outputs.out
+    ctx.actions.expand_template(
+        template = ctx.file.src,
+        output = output,
+        substitutions = substitutions,
+    )
+
+    return [
+        DefaultInfo(files = depset([output])),
+    ]
+
+_apple_preprocessed_plist = rule(
+    attrs = {
+        "src": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "The property list file that should be processed.",
+        ),
+        "out": attr.output(
+            mandatory = True,
+            doc = "The file reference for the output plist.",
+        ),
+        "keys": attr.string_list(
+            allow_empty = True,
+            mandatory = False,
+            default = [],
+            doc = "The attribute names to be expanded.",
+        ),
+        "values": attr.string_list(
+            allow_empty = True,
+            mandatory = False,
+            default = [],
+            doc = "The attribute values. The order should match the order of keys.",
+        ),
+    },
+    doc = """
+This rule generates the plist given the provided keys and values to be used for
+the substitution. Note that this does not compile your plist into the binary
+format.
+""",
+    fragments = ["apple"],
+    implementation = _impl,
+)
+
+def apple_preprocessed_plist(name, src, out, substitutions, **kwargs):
+    _apple_preprocessed_plist(
+        name = name,
+        src = src,
+        out = out,
+        keys = substitutions.keys(),
+        values = string_dict_select_values(substitutions.values()),
+        **kwargs
+    )

--- a/apple/string_dict_select_values.bzl
+++ b/apple/string_dict_select_values.bzl
@@ -1,0 +1,16 @@
+def string_dict_select_values(values):
+    select_values = []
+
+    for value in values:
+        if type(value) == type(""):
+            select_values += [value]
+        else:
+            select_values += select(_wrap_dict_values_in_array(value))
+
+    return select_values
+
+def _wrap_dict_values_in_array(d):
+    retval = {}
+    for key, value in d.items():
+        retval[key] = [value]
+    return retval


### PR DESCRIPTION
This is necessary before we can add an app example using the default
Info.plist from Xcode when you start a new project.