### PR TITLE
Add build status badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: build
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LINE's Apple rules for Bazel
+# LINE's Apple rules for Bazel ![](https://github.com/line/bazel_rules_apple/workflows/build/badge.svg)
 
 This repository contains additional rules for Bazel that can be used to bundle
 applications for Apple platforms.


### PR DESCRIPTION
Also rename the workflow name to make the rendered badge looks more
familiar with what we were used to -- for instance, Travis.