### PR TITLE
Add a full fledged example app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_11.5.app
       - name: Build
-        run: bazelisk build --subcommands //examples/ios/PureSwift:PureSwiftFramework //examples/ios/PureObjC:PureObjCFramework //examples/ios/Mixed:MixedFramework
+        run: bazelisk build --subcommands //examples/ios/PureSwift:PureSwiftFramework //examples/ios/PureObjC:PureObjCFramework //examples/ios/Mixed:MixedFramework //examples/ios/App

--- a/apple/apple_preprocessed_plist.bzl
+++ b/apple/apple_preprocessed_plist.bzl
@@ -2,7 +2,7 @@ load("//apple:string_dict_select_values.bzl", "string_dict_select_values")
 
 def _impl(ctx):
     substitutions = {}
-    for key, value in ctx.attr.items():
+    for key, value in zip(ctx.attr.keys, ctx.attr.values):
         substitutions["${" + key + "}"] = value
         substitutions["$(" + key + ")"] = value
 

--- a/examples/ios/App/BUILD
+++ b/examples/ios/App/BUILD
@@ -1,0 +1,49 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
+load(
+    "//examples/ios/App/Sources:constants.bzl",
+    "APP_EXECUTABLE_NAME",
+    "APP_IDENTIFIER",
+    "APP_VERSION",
+    "DEFAULT_MINIMUM_OS_VERSION",
+)
+
+ios_application(
+    name = "App",
+    app_icons = ["//examples/ios/App/Sources:AppIcon"],
+    bundle_id = select(APP_IDENTIFIER),
+    bundle_name = select(APP_EXECUTABLE_NAME),
+    extensions = [
+        "//examples/ios/App/ShareExtension:ShareExtension_appex",
+    ],
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = ["//examples/ios/App/Sources:PreprocessedInfoPlist"],
+    linkopts = select({
+        "//examples/ios/App/Configuration:Debug": [],
+        # Speed up link time of the app. The exported symbol list is only
+        # needed for an app if you're using that app as the bundle loader in tests.
+        "//conditions:default": [
+            "-exported_symbols_list",
+            "/dev/null",
+        ],
+    }),
+    minimum_os_version = DEFAULT_MINIMUM_OS_VERSION,
+    version = ":version",
+    visibility = ["//visibility:public"],
+    watch_application = "//examples/ios/App/WatchKitApp",
+    deps = ["//examples/ios/App/Sources:Main"],
+)
+
+apple_bundle_version(
+    name = "version",
+    build_label_pattern = "{timestamp_version}",
+    build_version = "{timestamp_version}",
+    capture_groups = {
+        "timestamp_version": ".*",
+    },
+    fallback_build_label = "1980.0101.000000",  # Low number so we can't accidentally upload it.
+    visibility = ["//visibility:public"],
+)

--- a/examples/ios/App/Configuration/BUILD
+++ b/examples/ios/App/Configuration/BUILD
@@ -1,0 +1,23 @@
+# Copyright 2020 LINE Corporation
+#
+# LINE Corporation licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+config_setting(
+    name = "Debug",
+    values = {"compilation_mode": "dbg"},
+)
+
+config_setting(
+    name = "Release",
+    values = {"compilation_mode": "opt"},
+)

--- a/examples/ios/App/ShareExtension/BUILD
+++ b/examples/ios/App/ShareExtension/BUILD
@@ -1,0 +1,37 @@
+load("//apple:swift_static_framework.bzl", "swift_static_framework")
+load("//apple:apple_preprocessed_plist.bzl", "apple_preprocessed_plist")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_extension")
+load(
+    "//examples/ios/App/Sources:constants.bzl",
+    "APP_IDENTIFIER",
+    "DEFAULT_MINIMUM_OS_VERSION",
+    "INFO_PLIST_DICT",
+)
+
+swift_static_framework(
+    name = "ShareExtension",
+    srcs = glob(["**/*.swift"]),
+    data = glob(["**/*.storyboard"]),
+)
+
+apple_preprocessed_plist(
+    name = "PreprocessedInfoPlist",
+    src = "Info.plist",
+    out = "Info-Preprocessed.plist",
+    substitutions = INFO_PLIST_DICT,
+)
+
+ios_extension(
+    name = "ShareExtension_appex",
+    bundle_id = select(APP_IDENTIFIER) + ".ShareExtension",
+    bundle_name = "ShareExtension",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [":PreprocessedInfoPlist"],
+    minimum_os_version = DEFAULT_MINIMUM_OS_VERSION,
+    version = "//examples/ios/App:version",
+    visibility = ["//examples/ios/App:__pkg__"],
+    deps = [":ShareExtension"],
+)

--- a/examples/ios/App/ShareExtension/Base.lproj/MainInterface.storyboard
+++ b/examples/ios/App/ShareExtension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Share View Controller-->
+        <scene sceneID="ceB-am-kn3">
+            <objects>
+                <viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="1Xd-am-t49"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/ios/App/ShareExtension/Info.plist
+++ b/examples/ios/App/ShareExtension/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ShareExtension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/examples/ios/App/ShareExtension/ShareViewController.swift
+++ b/examples/ios/App/ShareExtension/ShareViewController.swift
@@ -12,14 +12,20 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-import Foundation
+import UIKit
+import Social
 
-public class SwiftGreeter: NSObject {
-    @objc public class func sayHi(name: String) {
-        print("Hi \(name) from Swift")
+class ShareViewController: SLComposeServiceViewController {
+
+    override func isContentValid() -> Bool {
+        return true
     }
 
-    @objc public class func callObjC(name: String) {
-        MXDObjcGreeter.sayHi(name)
+    override func didSelectPost() {
+        self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+    }
+
+    override func configurationItems() -> [Any]! {
+        return []
     }
 }

--- a/examples/ios/App/Sources/AppDelegate.swift
+++ b/examples/ios/App/Sources/AppDelegate.swift
@@ -12,14 +12,20 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-import Foundation
+import UIKit
 
-public class SwiftGreeter: NSObject {
-    @objc public class func sayHi(name: String) {
-        print("Hi \(name) from Swift")
-    }
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
 
-    @objc public class func callObjC(name: String) {
-        MXDObjcGreeter.sayHi(name)
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        window?.rootViewController = ViewController()
+        window?.makeKeyAndVisible()
+
+        return true
     }
 }

--- a/examples/ios/App/Sources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/ios/App/Sources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/Sources/Assets.xcassets/Contents.json
+++ b/examples/ios/App/Sources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/Sources/BUILD
+++ b/examples/ios/App/Sources/BUILD
@@ -1,0 +1,49 @@
+# Copyright 2020 LINE Corporation
+#
+# LINE Corporation licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+load("//apple:apple_preprocessed_plist.bzl", "apple_preprocessed_plist")
+load("//apple:mixed_static_framework.bzl", "mixed_static_framework")
+load(
+    "//examples/ios/App/Sources:constants.bzl",
+    "INFO_PLIST_DICT",
+)
+
+mixed_static_framework(
+    name = "Main",
+    srcs = glob([
+        "**/*.swift",
+    ]),
+    data = glob([
+        "**/*.storyboard",
+    ]),
+    deps = [
+        "//examples/ios/Mixed",
+        "//examples/ios/PureObjC",
+        "//examples/ios/PureSwift",
+    ],
+)
+
+apple_preprocessed_plist(
+    name = "PreprocessedInfoPlist",
+    src = "Info.plist",
+    out = "Info-Preprocessed.plist",
+    substitutions = INFO_PLIST_DICT,
+    visibility = ["//examples/ios/App:__pkg__"],
+)
+
+filegroup(
+    name = "AppIcon",
+    srcs = glob([":Assets.xcassets/AppIcon.appiconset/**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/ios/App/Sources/Base.lproj/LaunchScreen.storyboard
+++ b/examples/ios/App/Sources/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/ios/App/Sources/Base.lproj/Main.storyboard
+++ b/examples/ios/App/Sources/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/ios/App/Sources/Info.plist
+++ b/examples/ios/App/Sources/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/ios/App/Sources/ViewController.swift
+++ b/examples/ios/App/Sources/ViewController.swift
@@ -12,17 +12,24 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-#import "ObjcGreeter.h"
-#import <Mixed/Mixed-Swift.h>
+import Mixed
+import PureObjC
+import PureSwift
+import UIKit
 
-@implementation ObjcGreeter
+class ViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+    }
 
-+ (void)sayHi:(NSString *)name {
-    printf("Hi %s\n from ObjC", [name UTF8String]);
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        let name = "LINE"
+        PureObjC.ObjcGreeter.sayHi(name)
+        PureSwift.SwiftGreeter.sayHi(name: name)
+        Mixed.MXDObjcGreeter.sayHi(name)
+        Mixed.SwiftGreeter.sayHi(name: name)
+    }
 }
-
-+ (void)callSwift:(NSString *)name {
-    [SwiftGreeter sayHiWithName:name];
-}
-
-@end

--- a/examples/ios/App/Sources/constants.bzl
+++ b/examples/ios/App/Sources/constants.bzl
@@ -1,0 +1,36 @@
+# Copyright 2020 LINE Corporation
+#
+# LINE Corporation licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+APP_VERSION = "1.0"
+
+APP_EXECUTABLE_NAME = {
+    "//conditions:default": "BazelSamples-Beta",
+    "//examples/ios/App/Configuration:Debug": "BazelSamples-Beta",
+    "//examples/ios/App/Configuration:Release": "BazelSamples",
+}
+
+APP_IDENTIFIER = {
+    "//conditions:default": "com.linecorp.BazelSamples.beta",
+    "//examples/ios/App/Configuration:Debug": "com.linecorp.BazelSamples.beta",
+    "//examples/ios/App/Configuration:Release": "com.linecorp.BazelSamples",
+}
+
+DEFAULT_MINIMUM_OS_VERSION = "11.0"
+
+DEFAULT_MINIMUM_WATCHOS_VERSION = "6.0"
+
+INFO_PLIST_DICT = {
+    "APP_IDENTIFIER": APP_IDENTIFIER,
+    "PRODUCT_BUNDLE_PACKAGE_TYPE": "AAPL",
+}

--- a/examples/ios/App/WatchKitApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/ios/App/WatchKitApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,81 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "24x24",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "27.5x27.5",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "40x40",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "44x44",
+      "subtype" : "40mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "50x50",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "86x86",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "98x98",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "108x108",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitApp/Assets.xcassets/Contents.json
+++ b/examples/ios/App/WatchKitApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitApp/BUILD
+++ b/examples/ios/App/WatchKitApp/BUILD
@@ -1,0 +1,50 @@
+# Copyright 2020 LINE Corporation
+#
+# LINE Corporation licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_application")
+load("//apple:apple_preprocessed_plist.bzl", "apple_preprocessed_plist")
+load(
+    "//examples/ios/App/Sources:constants.bzl",
+    "APP_EXECUTABLE_NAME",
+    "APP_IDENTIFIER",
+    "DEFAULT_MINIMUM_OS_VERSION",
+    "DEFAULT_MINIMUM_WATCHOS_VERSION",
+    "INFO_PLIST_DICT",
+)
+
+watchos_application(
+    name = "WatchKitApp",
+    app_icons = [":AppIcon"],
+    bundle_id = select(APP_IDENTIFIER) + ".WatchKitApp",
+    extension = "//examples/ios/App/WatchKitExtension",
+    infoplists = [":PreprocessedInfoPlist"],
+    minimum_os_version = DEFAULT_MINIMUM_WATCHOS_VERSION,
+    resources = [
+        "Base.lproj/Interface.storyboard",
+    ],
+    version = "//examples/ios/App:version",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "AppIcon",
+    srcs = glob(["Assets.xcassets/AppIcon.appiconset/**"]),
+)
+
+apple_preprocessed_plist(
+    name = "PreprocessedInfoPlist",
+    src = "Info.plist",
+    out = "Info-Preprocessed.plist",
+    substitutions = INFO_PLIST_DICT,
+)

--- a/examples/ios/App/WatchKitApp/Base.lproj/Interface.storyboard
+++ b/examples/ios/App/WatchKitApp/Base.lproj/Interface.storyboard
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="11134" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="3mp-fW-waa">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="11055"/>
+    </dependencies>
+    <scenes>
+        <!--Interface Controller-->
+        <scene sceneID="aou-V4-d1y">
+            <objects>
+                <hostingController id="3mp-fW-waa" customClass="HostingController"
+                customModuleProvider="target"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/ios/App/WatchKitApp/Info.plist
+++ b/examples/ios/App/WatchKitApp/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>WatchApp WatchKit App</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>$(APP_IDENTIFIER)</string>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -1,0 +1,48 @@
+{
+  "assets" : [
+    {
+      "filename" : "Circular.imageset",
+      "idiom" : "watch",
+      "role" : "circular"
+    },
+    {
+      "filename" : "Extra Large.imageset",
+      "idiom" : "watch",
+      "role" : "extra-large"
+    },
+    {
+      "filename" : "Graphic Bezel.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-bezel"
+    },
+    {
+      "filename" : "Graphic Circular.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-circular"
+    },
+    {
+      "filename" : "Graphic Corner.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-corner"
+    },
+    {
+      "filename" : "Graphic Large Rectangular.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-large-rectangular"
+    },
+    {
+      "filename" : "Modular.imageset",
+      "idiom" : "watch",
+      "role" : "modular"
+    },
+    {
+      "filename" : "Utilitarian.imageset",
+      "idiom" : "watch",
+      "role" : "utilitarian"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/Assets.xcassets/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/App/WatchKitExtension/BUILD
+++ b/examples/ios/App/WatchKitExtension/BUILD
@@ -1,0 +1,49 @@
+# Copyright 2020 LINE Corporation
+#
+# LINE Corporation licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_extension")
+load("//apple:apple_preprocessed_plist.bzl", "apple_preprocessed_plist")
+load("//apple:swift_static_framework.bzl", "swift_static_framework")
+load(
+    "//examples/ios/App/Sources:constants.bzl",
+    "APP_IDENTIFIER",
+    "DEFAULT_MINIMUM_WATCHOS_VERSION",
+    "INFO_PLIST_DICT",
+)
+
+watchos_extension(
+    name = "WatchKitExtension",
+    bundle_id = select(APP_IDENTIFIER) + ".WatchKitApp.WatchKitExtension",
+    infoplists = [":PreprocessedInfoPlist"],
+    minimum_os_version = DEFAULT_MINIMUM_WATCHOS_VERSION,
+    resources = glob([
+        "Assets.xcassets/**",
+    ]),
+    version = "//examples/ios/App:version",
+    visibility = ["//examples/ios/App/WatchKitApp:__pkg__"],
+    deps = [":WatchKitExtensionLib"],
+)
+
+swift_static_framework(
+    name = "WatchKitExtensionLib",
+    srcs = glob(["**/*.swift"]),
+    module_name = "WatchKitExtension",
+)
+
+apple_preprocessed_plist(
+    name = "PreprocessedInfoPlist",
+    src = "Info.plist",
+    out = "Info-Preprocessed.plist",
+    substitutions = INFO_PLIST_DICT,
+)

--- a/examples/ios/App/WatchKitExtension/ContentView.swift
+++ b/examples/ios/App/WatchKitExtension/ContentView.swift
@@ -12,14 +12,16 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-import Foundation
+import SwiftUI
 
-public class SwiftGreeter: NSObject {
-    @objc public class func sayHi(name: String) {
-        print("Hi \(name) from Swift")
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, World!")
     }
+}
 
-    @objc public class func callObjC(name: String) {
-        MXDObjcGreeter.sayHi(name)
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
     }
 }

--- a/examples/ios/App/WatchKitExtension/ExtensionsDelegate.swift
+++ b/examples/ios/App/WatchKitExtension/ExtensionsDelegate.swift
@@ -1,0 +1,38 @@
+// Copyright 2020 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+import WatchKit
+
+class ExtensionDelegate: NSObject, WKExtensionDelegate {
+    func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
+        for task in backgroundTasks {
+            switch task {
+            case let backgroundTask as WKApplicationRefreshBackgroundTask:
+                backgroundTask.setTaskCompletedWithSnapshot(false)
+            case let snapshotTask as WKSnapshotRefreshBackgroundTask:
+                snapshotTask.setTaskCompleted(restoredDefaultState: true, estimatedSnapshotExpiration: Date.distantFuture, userInfo: nil)
+            case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
+                connectivityTask.setTaskCompletedWithSnapshot(false)
+            case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
+                urlSessionTask.setTaskCompletedWithSnapshot(false)
+            case let relevantShortcutTask as WKRelevantShortcutRefreshBackgroundTask:
+                relevantShortcutTask.setTaskCompletedWithSnapshot(false)
+            case let intentDidRunTask as WKIntentDidRunRefreshBackgroundTask:
+                intentDidRunTask.setTaskCompletedWithSnapshot(false)
+            default:
+                task.setTaskCompletedWithSnapshot(false)
+            }
+        }
+    }
+}

--- a/examples/ios/App/WatchKitExtension/HostingController.swift
+++ b/examples/ios/App/WatchKitExtension/HostingController.swift
@@ -12,14 +12,12 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+import WatchKit
 import Foundation
+import SwiftUI
 
-public class SwiftGreeter: NSObject {
-    @objc public class func sayHi(name: String) {
-        print("Hi \(name) from Swift")
-    }
-
-    @objc public class func callObjC(name: String) {
-        MXDObjcGreeter.sayHi(name)
+class HostingController: WKHostingController<ContentView> {
+    override var body: ContentView {
+        return ContentView()
     }
 }

--- a/examples/ios/App/WatchKitExtension/Info.plist
+++ b/examples/ios/App/WatchKitExtension/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>WatchKitExtension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>$(APP_IDENTIFIER).WatchKitApp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+	<key>WKExtensionDelegateClassName</key>
+	<string>$(PRODUCT_NAME).ExtensionDelegate</string>
+	<key>WKWatchOnly</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/ios/App/WatchKitExtension/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/examples/ios/App/WatchKitExtension/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/ios/Mixed/MXDObjcGreeter.h
+++ b/examples/ios/Mixed/MXDObjcGreeter.h
@@ -12,14 +12,10 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-import Foundation
+#import <Foundation/Foundation.h>
 
-public class SwiftGreeter: NSObject {
-    @objc public class func sayHi(name: String) {
-        print("Hi \(name) from Swift")
-    }
+@interface MXDObjcGreeter : NSObject
 
-    @objc public class func callObjC(name: String) {
-        MXDObjcGreeter.sayHi(name)
-    }
-}
++ (void)sayHi:(NSString *)name;
+
+@end

--- a/examples/ios/Mixed/MXDObjcGreeter.m
+++ b/examples/ios/Mixed/MXDObjcGreeter.m
@@ -12,10 +12,17 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-#import <Foundation/Foundation.h>
+#import "MXDObjcGreeter.h"
+#import <Mixed/Mixed-Swift.h>
 
-@interface ObjcGreeter : NSObject
+@implementation MXDObjcGreeter
 
-+ (void)sayHi:(NSString *)name;
++ (void)sayHi:(NSString *)name {
+    printf("Hi %s\n from ObjC", [name UTF8String]);
+}
+
++ (void)callSwift:(NSString *)name {
+    [SwiftGreeter sayHiWithName:name];
+}
 
 @end


### PR DESCRIPTION
This patch adds an example iOS app --- an iOS app with dependencies
being Obj-C, Swift, and mixed-source modules, with a bundled extension
and a watch app. This app demonstrates how to use all the custom rules
in this repository to build a full fledged app.
