### PR TITLE
Collect transitive module maps from deps.

### DIFF
--- a/apple/objc_module_map_config.bzl
+++ b/apple/objc_module_map_config.bzl
@@ -1,0 +1,80 @@
+def _clang_config_file_content(module_maps):
+    """Returns the contents of a Clang configuration file given a depset of module maps."""
+
+    content = ""
+    for map in module_maps.to_list():
+        path = map.path
+
+        # Ignore module maps from the prebuilt frameworks. These are redundant
+        # because those frameworks are already being imported via the framework
+        # search paths flag (`-F`).
+        if ".framework" in path:
+            continue
+
+        # Ignore the auto-generated module maps by Bazel. We use our
+        # `module_map` rule to generate module maps instead of relying on
+        # Bazel's autogerated ones (they are only generated when being directly
+        # depended on a `swift_library` target, which is uncontrollable).
+        # Bazel's auto-generated module maps follow the naming convention
+        # `target_name.modulemaps/module.modulemap`.
+        if ".modulemaps" in path:
+            continue
+
+        content += "-fmodule-map-file="
+        content += path
+        content += "\n"
+    return content
+
+def _get_transitive_module_maps(deps):
+    """Returns a [depset](https://docs.bazel.build/versions/3.1.0/skylark/depsets.html) of transitive module maps given a depset of transitive dependencies.
+
+    Args:
+        deps: The cc_library, objc_library and swift_library dependencies.
+    Returns:
+        A depset of transitive module maps.
+    """
+    return depset(
+        transitive = [
+            dep[apple_common.Objc].module_map
+            for dep in deps
+            if apple_common.Objc in dep
+        ],
+    )
+
+def _objc_module_map_config_impl(ctx):
+    all_module_maps = _get_transitive_module_maps(ctx.attr.deps)
+    output = ctx.outputs.out
+    ctx.actions.write(
+        content = _clang_config_file_content(all_module_maps),
+        output = output,
+    )
+
+    return struct(
+        providers = [
+            DefaultInfo(
+                files = depset([output]),
+            ),
+            apple_common.new_objc_provider(
+                module_map = all_module_maps,
+            ),
+        ],
+    )
+
+objc_module_map_config = rule(
+    attrs = {
+        "deps": attr.label_list(
+            doc = "The dependencies from which to retrieve the list of module maps.",
+            mandatory = True,
+            providers = [CcInfo],
+        ),
+        "out": attr.output(
+            doc = "The output filename of the Clang configuration file.",
+            mandatory = True,
+        ),
+    },
+    doc = """
+Generates a Clang configuration file with all the `-fmodule-map-file` flags
+for all direct and transitive module maps from dependencies.
+""",
+    implementation = _objc_module_map_config_impl,
+)

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,29 @@ Generates a module map given a list of header files.
 | <a name="module_map-textual_hdrs"></a>textual_hdrs |  The list of C, C++, Objective-C, and Objective-C++ header files used to construct the module map. Unlike hdrs, these will be declared as 'textual header' in the module map.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
+<a name="#objc_module_map_config"></a>
+
+## objc_module_map_config
+
+<pre>
+objc_module_map_config(<a href="#objc_module_map_config-name">name</a>, <a href="#objc_module_map_config-deps">deps</a>, <a href="#objc_module_map_config-out">out</a>)
+</pre>
+
+
+Generates a Clang configuration file with all the `-fmodule-map-file` flags
+for all direct and transitive module maps from dependencies.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a name="objc_module_map_config-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a name="objc_module_map_config-deps"></a>deps |  The dependencies from which to retrieve the list of module maps.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a name="objc_module_map_config-out"></a>out |  The output filename of the Clang configuration file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+
+
 <a name="#apple_preprocessed_plist"></a>
 
 ## apple_preprocessed_plist

--- a/docs/doc_hub.bzl
+++ b/docs/doc_hub.bzl
@@ -16,6 +16,7 @@ load("//apple:apple_preprocessed_plist.bzl", _apple_preprocessed_plist = "apple_
 load("//apple:metal_library.bzl", _metal_library = "metal_library")
 load("//apple:mixed_static_framework.bzl", _mixed_static_framework = "mixed_static_framework")
 load("//apple:module_map.bzl", _module_map = "module_map")
+load("//apple:objc_module_map_config.bzl", _objc_module_map_config = "objc_module_map_config")
 load("//apple:objc_static_framework.bzl", _objc_static_framework = "objc_static_framework")
 load("//apple:swift_static_framework.bzl", _swift_static_framework = "swift_static_framework")
 
@@ -28,5 +29,6 @@ apple_preprocessed_plist = _apple_preprocessed_plist
 metal_library = _metal_library
 mixed_static_framework = _mixed_static_framework
 module_map = _module_map
+objc_module_map_config = _objc_module_map_config
 objc_static_framework = _objc_static_framework
 swift_static_framework = _swift_static_framework


### PR DESCRIPTION
Previously, when compiling our objc_library targets, we were iterating
through `deps`, manually constructing a new `*Module` target (a
`module_map` target) for each dependency, and implicitly adding them to
the objc_library's `deps`, so that we could pass all the required
`-fmodule-map-file=` flags, to make the modules import work in Obj-C
code. There were many problems with this approach:

* In most targets, transitive dependencies also have to be declared:
Those additional `copts` were added via macros, which don't have any
knowledge of the transitive dependencies, hence declaring all of them
was the only way to ensure there were no missing dependencies. This was
non-intuitive, and was becoming a dependency madness, as there are many
cases where you still have to declare dependencies that you're not even
using in your target.
* `select` was unusable with `deps`: Because the macro implementation
needs to iterate through the `deps` attribute, while `select` is not
iterable. This was a huge downside since it disallows us from
conditionally declaring dependencies based on configuration (e.g. debug
only dependencies), and based on feature flags.
* The implementation itself was bug-prone, since it relies on
manipulating each string item declared in `deps`.

[Clang configuration files](https://clang.llvm.org/docs/UsersManual.html#configuration-files) to the rescue.

This patch creates a new rule, `objc_module_map_config` that generates a
Clang configuration file that includes all the `-fmodule-map-file` flags
needed from the given dependencies. Since it's a real rule, it has all
the information about the dependencies (and dependencies' dependencies).
From the macros that use this rule (`objc_static_framework` and
`mixed_static_framework`), we only need to add one additionally flag,
`--config <config_file>`, and all the additionally flags in this file
will be passed to Clang for you.