### PR TITLE
Generate a dummy, unique symbol if there's no source files provided for objc_static_framework

### DIFF
--- a/apple/objc_static_framework.bzl
+++ b/apple/objc_static_framework.bzl
@@ -19,6 +19,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":headermap_support.bzl", "headermap_support")
 load(":module_map.bzl", "module_map")
 load(":objc_module_map_config.bzl", "objc_module_map_config")
+load(":unique_symbol_file.bzl", "unique_symbol_file")
 load(
     ":common.bzl",
     "DEFAULT_MINIMUM_OS_VERSION",
@@ -178,13 +179,14 @@ def objc_static_framework(
         objc_deps += [":" + name + "Import"]
         avoid_deps = []
 
-        # objc_library needs at least a source file
-        native.genrule(
-            name = name + "Dummy",
-            outs = [name + "Dummy.m"],
-            cmd = "touch $@",
+    # objc_library needs at least a source file
+    if not srcs:
+        unique_symbol_name = name + "UniqueSymbol"
+        unique_symbol_file(
+            name = unique_symbol_name,
+            out = name + "UniqueSymbol.m",
         )
-        srcs = [":{}Dummy.m".format(name)]
+        srcs = [":{}".format(unique_symbol_name)]
 
     objc_module_map_config_name = name + "_module_maps"
     objc_module_map_config(

--- a/apple/unique_symbol_file.bzl
+++ b/apple/unique_symbol_file.bzl
@@ -1,0 +1,64 @@
+"""Implementation of unique_symbol_file rule."""
+
+def _string_to_c_symbol(string):
+    """Converts a string to a valid C symbol
+
+    Args:
+      string: The string to convert
+
+    Returns:
+      The converted string
+    """
+    out = ""
+    for character in string.elems():
+        if character.isalnum():
+            out += character
+        else:
+            out += "_"
+    return out
+
+def _label_to_c_symbol(label):
+    """Converts a label to a valid C symbol
+
+    Args:
+      label: The label to convert
+
+    Returns:
+      The converted string
+    """
+    workspace = _string_to_c_symbol(label.workspace_root)
+    package = _string_to_c_symbol(label.package)
+    name = _string_to_c_symbol(label.name)
+
+    return "{workspace}{package}_{name}".format(
+        workspace = workspace,
+        package = package,
+        name = name,
+    )
+
+def _unique_symbol_file_impl(ctx):
+    output = ctx.outputs.out
+    label = _label_to_c_symbol(ctx.label)
+
+    content = """\
+__attribute__((visibility("default"))) char k{}ExportToSuppressLibToolWarning = 0;
+""".format(label)
+
+    ctx.actions.write(
+        output = output,
+        content = content,
+    )
+
+unique_symbol_file = rule(
+    implementation = _unique_symbol_file_impl,
+    attrs = {
+        "out": attr.output(
+            doc = "The name of the generated file.",
+            mandatory = True,
+        ),
+    },
+    doc = """
+Creates a source file with a unique symbol in it so that the linker does not
+generate warnings at link time for static libraries with no symbols in them.
+""",
+)


### PR DESCRIPTION
This is to suppress the empty table of contents libtool warnings at link
time.