### PR TITLE
implementation only member not able to work in a submodule

### DIFF
--- a/examples/ios/MixedWithPrivateSubmodule/SwiftGreeter.swift
+++ b/examples/ios/MixedWithPrivateSubmodule/SwiftGreeter.swift
@@ -16,6 +16,9 @@ import Foundation
 @_implementationOnly import submodule
 
 public class SwiftGreeter: NSObject {
+
+    public var submodule_greeter: submodule.SubModuleSwiftGreeter? = nil
+
     @objc public class func sayHi(name: String) {
         print("Hi \(name) from Swift")
     }


### PR DESCRIPTION
I worked to make the private submodule example more like my use case.  I realize the issue is that I want to be able to use the submodule as a member variable in my framework.  This complains with:  ```examples/ios/MixedWithPrivateSubmodule/SwiftGreeter.swift:20:16: error: cannot use module 'submodule' here; 'submodule' has been imported as implementation-only
    public var submodule_greeter: submodule.SubModuleSwiftGreeter? = nil```

 If I don't use it as a member variable, and just refer to the submodule inside member functions, all is well. Any pointers on this would be greatly appreciated. 