### PR TITLE
--incompatible_objc_compile_info_migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ replacements for the official Apple rules.
 * [module_map](docs/README.md#module_map)
 * [pkg_dsym](docs/README.md#pkg_dsym)
 
+## Requirements
+
+The latest versions of **rules_apple** and **rules_swift** rulesets require
+the usage of the [--incompatible_objc_compile_info_migration](https://docs.bazel.build/versions/master/command-line-reference.html#flag--incompatible_objc_compile_info_migration) flag to work correctly.
+
 ## Quick setup
 
 Add the following to your `WORKSPACE` file to add the external repositories,
@@ -136,4 +141,4 @@ License for the specific language governing permissions and limitations
 under the License.
 ```
 
-See [LICENSE](LICENSE) for more detail. 
+See [LICENSE](LICENSE) for more detail.

--- a/apple/mixed_static_framework.bzl
+++ b/apple/mixed_static_framework.bzl
@@ -303,6 +303,7 @@ def mixed_static_framework(
           (the common use case), an umbrella header will be generated under the
           same name as this target.
       visibility: The visibility specifications for this target.
+      minimum_os_version: Minimum os version.
       **kwargs: Additional arguments being passed through.
     """
     swift_srcs = []


### PR DESCRIPTION
Update docs to reflect need to use `--incompatible_objc_compile_info_migration` when using latest apple/swift rulesets. Also fixes a Buildifier warning 