### PR TITLE
bundle name fix

### DIFF
--- a/apple/mixed_static_framework.bzl
+++ b/apple/mixed_static_framework.bzl
@@ -469,7 +469,7 @@ def mixed_static_framework(
             ":" + objc_library_name,
         ],
         avoid_deps = avoid_deps,
-        bundle_name = name,
+        bundle_name = module_name,
         minimum_os_version = minimum_os_version,
         umbrella_header = umbrella_header,
     )

--- a/apple/objc_static_framework.bzl
+++ b/apple/objc_static_framework.bzl
@@ -230,7 +230,7 @@ def objc_static_framework(
     ios_static_framework(
         name = name + "Framework",
         avoid_deps = avoid_deps,
-        bundle_name = name,
+        bundle_name = module_name,
         hdrs = hdrs + textual_hdrs,
         testonly = testonly,
         minimum_os_version = minimum_os_version,

--- a/apple/swift_static_framework.bzl
+++ b/apple/swift_static_framework.bzl
@@ -315,7 +315,7 @@ def swift_static_framework(
             ":" + objc_library_name,
         ],
         avoid_deps = avoid_deps,
-        bundle_name = name,
+        bundle_name = module_name,
         minimum_os_version = minimum_os_version,
     )
 


### PR DESCRIPTION
Since the correct bundle name is not being send to the native rules it is not using the module_name defined in the BUILD file, this causes this error:

```
omarzl@mbp-omar issue_bundle_name_demo % bazel build //:Mixed-LibFramework                                                   
INFO: Analyzed target //:Mixed-LibFramework (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: /Users/omarzl/Documents/Rappi/dev/bazel/issue_bundle_name_demo/BUILD.bazel:5:14: Compiling Swift module Mixed_Lib failed (Exit 1): worker failed: error executing command bazel-out/host/bin/external/build_bazel_rules_swift/tools/worker/worker swiftc @bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-1665503f7bef/bin/Mixed_Lib.swiftmodule-0.params
/private/var/tmp/_bazel_omarzl/d4b15372538f584ee97a74abbcce56ce/execroot/__main__/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-1665503f7bef/bin/Swift-Lib.intermediate-intermediates/module.modulemap:1:24: error: expected module declaration
framework module Swift-Lib {
Target //:Mixed-LibFramework failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.662s, Critical Path: 0.58s
INFO: 3 processes: 3 internal.
FAILED: Build did NOT complete successfully
```

Here is more information about this issue https://github.com/line/rules_apple_line/issues/20