### PR TITLE
infoplist path with spaces fix

### DIFF
--- a/apple/apple_resource_bundle.bzl
+++ b/apple/apple_resource_bundle.bzl
@@ -50,7 +50,7 @@ def apple_resource_bundle(
         outs = modified_infoplists,
         message = "Substitute variables in {}".format(infoplist),
         cmd = """
-plutil -replace CFBundleIdentifier -string {} -o $@ $<
+plutil -replace CFBundleIdentifier -string {} -o "$@" "$<"
 """.format(bundle_id),
     )
 


### PR DESCRIPTION
This pr fixes the case where the info plist path has spaces, detailed info can be found in this link https://stackoverflow.com/a/17094284/5374189