### PR TITLE
Update `objc_library` reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -347,7 +347,7 @@ rules in this repository.
 To use this rule in your BUILD files, load it with:
 
 ```starlark
-load("@rules_apple_line//apple:objc_library.bzl", "objc_library")
+load("@rules_apple_line//apple:swift_library.bzl", "swift_library")
 ```
 
 See [swift_static_framework](#swift_static_framework) for the documentation


### PR DESCRIPTION
This was the wrong macro for this documentation block