### PR TITLE
Cannot consume generated swift.h via a convenience

### DIFF
--- a/examples/ios/Mixed/MXDObjcGreeter.m
+++ b/examples/ios/Mixed/MXDObjcGreeter.m
@@ -13,7 +13,7 @@
 // under the License.
 
 #import "MXDObjcGreeter.h"
-#import <Mixed/Mixed-Swift.h>
+#import "Swift-Convenience.h"
 
 @implementation MXDObjcGreeter
 

--- a/examples/ios/Mixed/Swift-Convenience.h
+++ b/examples/ios/Mixed/Swift-Convenience.h
@@ -1,0 +1,1 @@
+#import <Mixed/Mixed-Swift.h>


### PR DESCRIPTION
I am looking to consume a generated `-Swift.h` header by using a
convenience import (so I can import
other libraries that are transitively required before importing
my `-Swift.h`).